### PR TITLE
Split build and push step in two for PRs

### DIFF
--- a/.github/workflows/build-image-on-pr.yml
+++ b/.github/workflows/build-image-on-pr.yml
@@ -25,11 +25,9 @@ jobs:
         REGISTRY_PASSWORD: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
       run: |
         echo "setting build version"
-        RELEASE_VERSION="$(date +%F)-$(git rev-parse --short HEAD)"
+        export RELEASE_VERSION="$(date +%F)-$(git rev-parse --short HEAD)"
         VERSION_FILE=realopinsight.pro
-        VERSION_LINE=$(grep -n '^PACKAGE_VERSION=' $VERSION_FILE | cut -f1 -d:)
-        VERSION_ORIG=$(grep '^PACKAGE_VERSION=' $VERSION_FILE | cut -d= -f2)
-        sed -i "${VERSION_LINE}s/${VERSION_ORIG}/${RELEASE_VERSION}/" $VERSION_FILE
+        perl -pi -e 's/^(PACKAGE_VERSION=).*/$1$ENV{RELEASE_VERSION}/' $VERSION_FILE
         cat $VERSION_FILE
 
         echo "building container image => ${IMAGE_BASENAME}:${RELEASE_VERSION}"

--- a/.github/workflows/build-image-on-pr.yml
+++ b/.github/workflows/build-image-on-pr.yml
@@ -18,11 +18,9 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Build and push Docker image
+    - name: Build Docker image
       env:
         IMAGE_BASENAME: rchakode/realopinsight
-        REGISTRY_USERNAME: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
-        REGISTRY_PASSWORD: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
       run: |
         echo "setting build version"
         export RELEASE_VERSION="$(date +%F)-$(git rev-parse --short HEAD)"
@@ -33,5 +31,12 @@ jobs:
         echo "building container image => ${IMAGE_BASENAME}:${RELEASE_VERSION}"
         IMAGE_TAGGED_NAME=${IMAGE_BASENAME}:${RELEASE_VERSION}
         docker build -t ${IMAGE_TAGGED_NAME} .
+        echo "IMAGE_TAGGED_NAME=$IMAGE_TAGGED_NAME" >> "$GITHUB_ENV"
+
+    - name: Push Docker image
+      env:
+        REGISTRY_USERNAME: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
+        REGISTRY_PASSWORD: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
+      run: |
         docker login --username ${REGISTRY_USERNAME} --password ${REGISTRY_PASSWORD}
         docker push $IMAGE_TAGGED_NAME

--- a/.github/workflows/build-image-on-pr.yml
+++ b/.github/workflows/build-image-on-pr.yml
@@ -34,6 +34,7 @@ jobs:
         echo "IMAGE_TAGGED_NAME=$IMAGE_TAGGED_NAME" >> "$GITHUB_ENV"
 
     - name: Push Docker image
+      if: github.event.pull_request.head.repo.full_name == github.repository
       env:
         REGISTRY_USERNAME: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
         REGISTRY_PASSWORD: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}


### PR DESCRIPTION
PRs from forks do not get access to write tokens or secrets when run from `pull_request` events. -- This is a good thing, because most devs (myself included) write code that's subject to arbitrary code execution, and if GitHub/we allowed users to create PRs with write tokens or secrets, they'd abuse them in interesting ways...

---

When I created PR #31, the docker image failed to publish:

<details><summary>The current code error</summary>

https://github.com/rchakode/realopinsight/actions/runs/5704974215/workflow?pr=31
https://github.com/rchakode/realopinsight/actions/runs/5704974215/job/15459124858?pr=31#step:3:1222
> Error: Cannot perform an interactive login from a non TTY device

</details>

This is a symptom of not having access to the docker secrets.

---

As a starting point, before enabling PRs from forks to trigger pushing images to docker, let's do some simple things:
1. ensure that github permissions for this workflow are restricted to readonly (#34) (note that PRs from forks will naturally only get read permissions, but in order to get access to secrets, changes are required that would change this default)
2. try to prevent arbitrary code execution in the build step (I actually wrote a sample value that triggered arbitrary code execution in the current `sed` based code. Fwiw, `patch` had a problem similar to this in various flavors: https://rachelbythebay.com/w/2018/04/05/bangpatch/)
3. Try to push as a separate step, this will fail for forks (as it did for pr 31), but that's ok, it's still incremental progress. Splitting this step out means that the build step could never have access to the secrets (which is a good thing).
4. To avoid failing for PRs from forks, let's include a commit that skips the push step in that case.

Note that `perl` should be seen as slightly scary. I'd encourage you to find someone who is comfortable w/ perl (this could be you, but it might be someone else -- you shouldn't trust me [for many reasons... I make mistakes or I could be evil]). The `sed` code was not safe, and while I _think_ that this `perl` code is safe, I could be very wrong.

Thankfully, while the `sed` code wasn't safe, at this point anyone making a PR from a fork can't do much because they'll get a readonly github `contents` token and will not get docker credentials (because `pull_request` doesn't include `secrets` for PRs from forks).

---

It _might_ be desirable for it to be able to be published....

It is possible to allow PRs from forks to trigger docker pushes, but:
1. I'd suggest you set up a distinct docker org and set of credentials for PR builds
2. It might be worth requiring approvals before running workflows from unknown contributors (or something like this)
3. with those changes, It's possible to then change the workflow so that it gets access to a secret when running from forks and could then publish with it.